### PR TITLE
workflow: create target directory if it doesn't exist

### DIFF
--- a/bin/workflow
+++ b/bin/workflow
@@ -1958,6 +1958,12 @@ conf.$project_name-configuration
 
 	my $target_file_configuration = "$target_directory/$grc_configuration";
 
+	if (not -e $target_directory)
+	{
+		my $command = "mkdir -p $target_directory";
+		execute_shell_command($command, { sudo => 1, }, );
+	}
+
 	if (-e $source_file_configuration
 	    and not -e $target_file_configuration)
 	{


### PR DESCRIPTION
This fixes the following error message, raised when calling 'install_scripts' for the very first project:

ln: failed to create symbolic link '/usr/share/grc/conf.test_project-configuration': No such file or directory
/usr/local/bin/workflow: *** Fatal: sudo     ln -sf /home/rme/projects/test/conf.test_project-configuration /usr/share/grc/conf.test_project-configuration failed with exit status 256

---

Note that these are my very first lines of perl code, so you might want to triple-check them.